### PR TITLE
Replace colours with colour picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,50 +1,41 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>DrawJS</title>
-    <link rel="stylesheet" href="./style.css" />
-  </head>
-  <body>
-    <div class="wrapper">
-      <div class="canvasContainer">
-        <canvas id="canvas"></canvas>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DrawJS</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+
+<body>
+  <div class="wrapper">
+    <div class="canvasContainer">
+      <canvas id="canvas"></canvas>
+    </div>
+    <div id="tools">
+      <div>
+        <button id="clear">CLEAR</button>
+        <button id="save">SAVE</button>
       </div>
-      <div id="tools">
-        <div>
-          <button id="clear">CLEAR</button>
-          <button id="save">SAVE</button>
-        </div>
-        <div id="colors">
-          <img
-            id="modeImg"
-            src="https://img.icons8.com/ios-filled/50/000000/eraser.png"
-          />
-          <div class="color" style="background-color: black"></div>
-          <div class="color" style="background-color: #6bd0ff"></div>
-          <div class="color" style="background-color: #cf0079"></div>
-          <div class="color" style="background-color: #fb4c4c"></div>
-          <div class="color" style="background-color: #ffcf11"></div>
-          <div class="color" style="background-color: #008616"></div>
-          <div class="color" style="background-color: #006de2"></div>
-          <div class="color" style="background-color: #4cfbb2"></div>
-          <div class="color" style="background-color: #d3ff11"></div>
-        </div>
-        <div class="size">
-          <input
-            class="strokeSize"
-            type="range"
-            min="1"
-            value="5"
-            max="30"
-            id="strokeSize"
-          />
-          <div class="sizeLabel">Pen Size: 5</div>
-        </div>
+      <div id="colors">
+        <img id="modeImg" src="https://img.icons8.com/ios-filled/50/000000/eraser.png" />
+        <div class="color" style="background-color: black"></div>
+        <label class="color-picker-button">
+          <img src="https://img.icons8.com/fluency/344/rgb-circle-2.png" alt="Choose colour">
+          <input type="color" name="color-picker" id="color-picker" value="#000000">
+        </label>
+
+
+      </div>
+      <div class="size">
+        <input class="strokeSize" type="range" min="1" value="5" max="30" id="strokeSize" />
+        <div class="sizeLabel">Pen Size: 5</div>
       </div>
     </div>
-    <script src="./script.js"></script>
-  </body>
+  </div>
+  <script src="./script.js"></script>
+</body>
+
 </html>

--- a/script.js
+++ b/script.js
@@ -1,124 +1,122 @@
-const canvas = document.querySelector("#canvas");
-const strokeSize = document.querySelector("#strokeSize");
-const clearButton = document.querySelector("#clear");
-const saveButton = document.querySelector("#save");
+const canvas = document.querySelector('#canvas')
+const strokeSize = document.querySelector('#strokeSize')
+const clearButton = document.querySelector('#clear')
+const saveButton = document.querySelector('#save')
 
-const modeImg = document.querySelector("#modeImg");
+const modeImg = document.querySelector('#modeImg')
 
-let pencil = true;
+let pencil = true
 
-const ctx = canvas.getContext("2d");
+const ctx = canvas.getContext('2d')
 
 const resize = () => {
   canvas.width =
-    document.documentElement.clientWidth || document.body.clientWidth;
+    document.documentElement.clientWidth || document.body.clientWidth
   canvas.height =
-    document.documentElement.clientHeight || document.body.clientHeight;
-};
+    document.documentElement.clientHeight || document.body.clientHeight
+}
 
 const changeColor = (e) => {
-  selectedColor = e.target.style.backgroundColor;
-
-  if(!pencil) {
-    selectedSize = strokeSize.value;
-    modeImg.src = "https://img.icons8.com/ios-filled/50/000000/eraser.png";
-    document.querySelector(".canvasContainer").style.cursor =
-      " url(https://img.icons8.com/ios-filled/50/000000/pencil-tip.png) 0 50, auto";
-    pencil = true;
+  selectedColor = e.target.style.backgroundColor || e.target.value
+  if (!pencil) {
+    selectedSize = strokeSize.value
+    modeImg.src = 'https://img.icons8.com/ios-filled/50/000000/eraser.png'
+    document.querySelector('.canvasContainer').style.cursor =
+      ' url(https://img.icons8.com/ios-filled/50/000000/pencil-tip.png) 0 50, auto'
+    pencil = true
   }
-  
-
-};
+}
 
 window.onload = () => {
-  resize();
-  document.querySelectorAll(".color").forEach((el) => {
-    el.addEventListener("click", changeColor);
-  });
-};
+  resize()
+  document.querySelectorAll('.color').forEach((el) => {
+    el.addEventListener('click', changeColor)
+  })
+  document.getElementById('color-picker').addEventListener('input', changeColor)
+}
 
 window.onresize = () => {
-  resize();
-};
+  resize()
+}
 
-let isDrawing = false;
-let selectedColor = "black";
-let selectedSize = 5;
+let isDrawing = false
+let selectedColor = 'black'
+let selectedSize = 5
 
-strokeSize.addEventListener("input", (e) => {
-  selectedSize = e.target.value;
+strokeSize.addEventListener('input', (e) => {
+  selectedSize = e.target.value
   document.querySelector(
-    ".sizeLabel"
-  ).textContent = `Pen Size: ${e.target.value}`;
-});
+    '.sizeLabel'
+  ).textContent = `Pen Size: ${e.target.value}`
+})
 
-clearButton.addEventListener("click", () => {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-});
+clearButton.addEventListener('click', () => {
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+})
 
-saveButton.addEventListener("click", () => {
-  const image = canvas.toDataURL();
-  const link = document.createElement("a");
-  link.href = image;
-  link.download = "DrawJS";
-  link.click();
-});
+saveButton.addEventListener('click', () => {
+  const image = canvas.toDataURL()
+  const link = document.createElement('a')
+  link.href = image
+  link.download = 'DrawJS'
+  link.click()
+})
 
 const configureContext = () => {
-  ctx.lineWidth = selectedSize;
-  ctx.lineCap = "round";
-  ctx.strokeStyle = selectedColor;
-};
+  ctx.lineWidth = selectedSize
+  ctx.lineCap = 'round'
+  ctx.strokeStyle = selectedColor
+}
 
 const beginDrawing = (e) => {
-  isDrawing = true;
-  configureContext();
-  draw(e);
-};
+  isDrawing = true
+  configureContext()
+  draw(e)
+}
 
 const endDrawing = () => {
-  isDrawing = false;
-  ctx.beginPath();
-};
+  isDrawing = false
+  ctx.beginPath()
+}
 
 const draw = (e) => {
   if (!isDrawing) {
-    return;
+    return
   }
 
   ctx.lineTo(
     e.clientX || e.touches[0].clientX,
     e.clientY || e.touches[0].clientY
-  );
-  ctx.stroke();
-  ctx.beginPath();
+  )
+  ctx.stroke()
+  ctx.beginPath()
   ctx.moveTo(
     e.clientX || e.touches[0].clientX,
     e.clientY || e.touches[0].clientY
-  );
-};
+  )
+}
 
 const changeMode = () => {
   if (pencil === true) {
-    selectedSize = 30;
-    selectedColor = "#FFFFFF";
-    modeImg.src = "https://img.icons8.com/ios-filled/50/000000/pencil-tip.png";
-    document.querySelector(".canvasContainer").style.cursor =
-      " url(https://img.icons8.com/ios-filled/50/000000/eraser.png) 25 25, auto";
+    selectedSize = 30
+    selectedColor = '#FFFFFF'
+    modeImg.src = 'https://img.icons8.com/ios-filled/50/000000/pencil-tip.png'
+    document.querySelector('.canvasContainer').style.cursor =
+      ' url(https://img.icons8.com/ios-filled/50/000000/eraser.png) 25 25, auto'
   } else {
-    selectedSize = strokeSize.value;
-    selectedColor = "#000000";
-    modeImg.src = "https://img.icons8.com/ios-filled/50/000000/eraser.png";
-    document.querySelector(".canvasContainer").style.cursor =
-      " url(https://img.icons8.com/ios-filled/50/000000/pencil-tip.png) 0 50, auto";
+    selectedSize = strokeSize.value
+    selectedColor = '#000000'
+    modeImg.src = 'https://img.icons8.com/ios-filled/50/000000/eraser.png'
+    document.querySelector('.canvasContainer').style.cursor =
+      ' url(https://img.icons8.com/ios-filled/50/000000/pencil-tip.png) 0 50, auto'
   }
-  pencil = !pencil;
-};
+  pencil = !pencil
+}
 
-canvas.addEventListener("mousedown", beginDrawing);
-canvas.addEventListener("touchstart", beginDrawing, { passive: true });
-canvas.addEventListener("mouseup", endDrawing);
-canvas.addEventListener("touchend", endDrawing, { passive: true });
-canvas.addEventListener("mousemove", draw);
-canvas.addEventListener("touchmove", draw, { passive: true });
-modeImg.addEventListener("click", changeMode);
+canvas.addEventListener('mousedown', beginDrawing)
+canvas.addEventListener('touchstart', beginDrawing, { passive: true })
+canvas.addEventListener('mouseup', endDrawing)
+canvas.addEventListener('touchend', endDrawing, { passive: true })
+canvas.addEventListener('mousemove', draw)
+canvas.addEventListener('touchmove', draw, { passive: true })
+modeImg.addEventListener('click', changeMode)

--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ body,
 
 body {
   z-index: 1;
+  font-family: Arial, Helvetica, sans-serif;
 }
 
 .wrapper {
@@ -85,6 +86,25 @@ body {
   margin: 10px;
   cursor: pointer;
 }
+.color-picker-button {
+  position: relative;
+}
+
+.color-picker-button img {
+  max-width: 60px;
+  height: auto;
+  position: relative;
+  z-index: 2;
+}
+
+.color-picker-button input {
+  position: absolute;
+  appearance: none;
+  left: 50%;
+  top: 50%;
+  width: 0;
+  height: 0;
+}
 
 button {
   font-size: large;
@@ -105,6 +125,10 @@ button {
     height: 30px;
     width: 30px;
     margin: 5px;
+  }
+
+  .color-picker-button img {
+    max-width: 36px;
   }
 
   #modeImg {


### PR DESCRIPTION
- Instead of adding colour buttons, use a HTML5 colour selector.
- Apply Arial as default font to fix font at "pencil size" selector.

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/11704483/193400463-f7affe49-036e-4cc4-accf-9257865d124f.png">
<img width="348" alt="image" src="https://user-images.githubusercontent.com/11704483/193400521-d1fb0763-66b4-4da6-af9c-a747da2027c4.png">
